### PR TITLE
Add use client directives

### DIFF
--- a/src/GithubIssueLink/GithubIssueLink.tsx
+++ b/src/GithubIssueLink/GithubIssueLink.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { PropsWithChildren, useContext, useEffect, useState } from "react";
 
 import {  GithubPermalinkContext, GithubIssueLinkDataResponse } from "../GithubPermalinkContext";

--- a/src/GithubPermalink/GithubPermalink.tsx
+++ b/src/GithubPermalink/GithubPermalink.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { PropsWithChildren, useContext, useEffect, useState } from "react";
 import ReactSyntaxHighlighter from "react-syntax-highlighter";
 import {  github, tomorrowNight } from 'react-syntax-highlighter/dist/cjs/styles/hljs';

--- a/src/GithubPermalinkContext.tsx
+++ b/src/GithubPermalinkContext.tsx
@@ -1,3 +1,4 @@
+"use client"
 import { PropsWithChildren, createContext } from "react";
 import { parseGithubIssueLink, parseGithubPermalinkUrl } from "./utils/urlParsers";
 

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,3 +1,5 @@
+"use client"
 export * from "./GithubPermalink/GithubPermalink"; 
 export * from "./GithubIssueLink/GithubIssueLink";
 export * from "./GithubPermalinkContext";
+export * from "./foo";


### PR DESCRIPTION
Adds use client directives so this can be used with nextjs 


Note that I ran into this weird issue - where you need to add a "use client" to the exports.ts 

https://stackoverflow.com/questions/75261466/unsupported-server-component-type-undefined-next-js-13

For now I'll make do with that solution - but some point in the future we'll want to allow this package to also export RSCs
